### PR TITLE
Add option to override view transformer in Select2Type

### DIFF
--- a/Form/Type/Select2Type.php
+++ b/Form/Type/Select2Type.php
@@ -60,7 +60,7 @@ class Select2Type extends AbstractType
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        if ($this->widget === 'ajax' && $options['multiple'] === true){
+        if ($options['apply_view_transformer'] && $this->widget === 'ajax' && $options['multiple'] === true) {
             $builder->addViewTransformer($this->transformer);
         }
     }
@@ -95,6 +95,7 @@ class Select2Type extends AbstractType
         );
         
         $defaults = array(
+            'apply_view_transformer' => true,
             'multiple' => false,
             'expanded' => false,
             'empty_value' => 'select.empty_value',

--- a/Resources/doc/select2.md
+++ b/Resources/doc/select2.md
@@ -54,6 +54,7 @@ public function buildForm(FormBuilderInterface $builder, array $options)
     $builder
         // .....
         ->add('name', 'thrace_select2_ajax', array(
+            'apply_view_transformer' => true,
             'label' => 'Select', 
             'multiple' => false,
             'empty_value' => 'Select option',
@@ -80,6 +81,7 @@ public function buildForm(FormBuilderInterface $builder, array $options)
     ;
 }
 ```
+**Note:** *apply_view_transformer* option enables \Thrace\FormBundle\Form\DataTransformer\ArrayToStringTransformer as the default transformer -only if **multiple** is set true-, setting it **false** allows you to use your own transformer
 
 And the array structure:
 

--- a/Tests/Form/Type/Select2TypeTest.php
+++ b/Tests/Form/Type/Select2TypeTest.php
@@ -22,6 +22,28 @@ class Select2TypeTest extends TypeTestCase
         ), $configs);
     }
 
+    public function testAjaxMultipleWithoutViewTransformer()
+    {
+        $form = $this->factory->create(
+            'thrace_select2_ajax',
+            null,
+            array(
+                'multiple'               => true,
+                'configs'                => array('ajax' => array(),'apply_view_transformer' => false)
+            )
+        );
+        $view = $form->createView();
+        $configs = $view->vars['configs'];
+        $this->assertSame(array(
+                'width' => '300px',
+                'allowClear' => true,
+                'ajax' => array (),
+                'apply_view_transformer' => false,
+                'placeholder' => 'select.empty_value',
+                'multiple' => true,
+            ), $configs);
+    }
+
     public function testAjaxAndMultiple()
     {
         $form = $this->factory->create('thrace_select2_ajax', null, array(


### PR DESCRIPTION
In some cases, developer may want to override the view transformer by his own, this PR adds the option to disable the \Thrace\FormBundle\Form\DataTransformer\ArrayToStringTransformer as well as test case covers this option
