### PR TITLE
Fix a bug with the raty icon path.

### DIFF
--- a/Resources/views/Form/fields.html.twig
+++ b/Resources/views/Form/fields.html.twig
@@ -79,7 +79,7 @@
 {% spaceless %}
     {{ form_widget(form, { 'attr': {'style': 'display:none'} }) }}
     <div id="thrace-rating-widget-{{ id }}"></div>
-    <span class="thrace-rating" data-options="{{ configs|merge({'id': id, 'path': asset(configs.path)})|json_encode }}" style="display:none"></span>  
+    <span class="thrace-rating" data-options="{{ configs|merge({'id': id, 'path': configs.path})|json_encode }}" style="display:none"></span>
 {% endspaceless %}
 {% endblock thrace_rating_widget %}
 


### PR DESCRIPTION
The raty star rating images fail to load if [assets_version](http://symfony.com/doc/current/reference/configuration/framework.html#assets-version) is set.

Fixes #11
